### PR TITLE
Return non-participating capture groups as empty strings

### DIFF
--- a/Source/Regex.swift
+++ b/Source/Regex.swift
@@ -31,10 +31,8 @@ public struct Match {
     
     public init(baseString string: String, checkingResult: NSTextCheckingResult) {
         matchedString = string.substringWithRange(checkingResult.range)
-        captureGroups = checkingResult.ranges.dropFirst().filter {
-            $0.location != NSNotFound
-        }.map {
-            string.substringWithRange($0)
+        captureGroups = checkingResult.ranges.dropFirst().map { range in
+            range.location == NSNotFound ? "" : string.substringWithRange(range)
         }
     }
 }

--- a/Tests/RegexTests.swift
+++ b/Tests/RegexTests.swift
@@ -19,7 +19,7 @@ class RegexTests: XCTestCase {
         
         XCTAssertNotNil(regex)
         let match1 = regex?.matches("a")     // Captures "a"
-        let match2 = regex?.matches("b")     // Matches "b", no capture
+        let match2 = regex?.matches("b")     // Matches "b", Captures ""
         
         XCTAssertEqual(match1?.count, 1)
         
@@ -30,7 +30,8 @@ class RegexTests: XCTestCase {
         XCTAssertEqual(match2?.count, 1)
         
         XCTAssertEqual(match2?.first?.matchedString, "b")
-        XCTAssertEqual(match2?.first?.captureGroups.count, 0)
+        XCTAssertEqual(match2?.first?.captureGroups.count, 1)
+        XCTAssertEqual(match2?.first?.captureGroups.first, "")
     }
     
 }


### PR DESCRIPTION
Related to bug #1. This PR changes the behavior to return empty strings instead of entirely skipping non-participating capture groups.

Say for example you want to strip all occurrences of the word "foo" from the beginning of a string. You might do that like this:
```
let regex = Regex(pattern: "^(foo )*(.*)$")!
let match1 = regex.matches("bar")       // Captures ["bar"]
let match2 = regex.matches("foo bar")   // Captures ["foo", "bar"]
```
You would not know whether to pick the first or the second capture group. With this PR the first match would capture `["", "bar"]` and all capture groups would maintain their indices regardless of what other capture groups participated.